### PR TITLE
make path include folders for status and speaker

### DIFF
--- a/s5_base/local/samromur_prep_data.py
+++ b/s5_base/local/samromur_prep_data.py
@@ -3,7 +3,7 @@
 # Author: David Erik Mollberg, Inga Run Helgadottir (Reykjavik University), Staffan Hedström
 # Description:
 # This script will output the files text, wav.scp, utt2spk, spk2utt and spk2gender
-# to data/train, data/eval data/test with test/train/eval splits defined in the metadatafile.
+# to data/train, data/dev data/test with test/train/dev splits defined in the metadatafile.
 
 import subprocess
 import argparse
@@ -14,9 +14,9 @@ import pandas as pd
 def parse_arguments():
     parser = argparse.ArgumentParser(
         description="""This script will output the files text, wav.scp, utt2spk, spk2utt and spk2gender\n
-        to data/train, data/eval and data/test, with test/train/eval splits defined in the metadatafile.\n
-        Usage: python3 samromur_prep_data.py <path-to-samromur-audio> <info-file-training>\n
-            E.g. python3 samromur_prep_data.py /data/corpora/samromur/audio/ metadata.tsv\n
+        to data/train, data/dev and data/test, with test/train/eval splits defined in the metadatafile.\n
+        Usage: python3 samromur_prep_data.py <path-to-samromur-audio> <info-file-training> <output-directory>\n
+            E.g. python3 samromur_prep_data.py /data/corpora/samromur/audio/ metadata.tsv /data/corpora/samromur/prep_output\n
         """
     )
     parser.add_argument(
@@ -89,7 +89,13 @@ def main():
     outdir = args.output_dir
     Path(outdir).mkdir(parents=True, exist_ok=True)
 
-    df = pd.read_csv(metadata, sep="\t", index_col="id", dtype={'is_valid': object})
+    # dtype fixes low mixed types warning
+    df = pd.read_csv(
+        metadata,
+        sep="\t",
+        index_col="id",
+        dtype={"is_valid": object, "age": object, "marosijo_score": object},
+    )
 
     for data_file in ["train", "dev", "eval"]:
         datadir = Path(outdir).joinpath(data_file)

--- a/s5_base/local/samromur_prep_data.py
+++ b/s5_base/local/samromur_prep_data.py
@@ -52,13 +52,21 @@ def append_to_file(df, audio_dir: str, text, wavscp, utt2spk, spk2gender):
     for i in df.index:
         utt_id = f"{df.at[i, 'speaker_id']}-{i}"
         text.write(f"{utt_id} {df.at[i, 'sentence_norm']}\n")
+
+        # Handle folder structure for test-dev-train/padded_speaker_id/file
+        # Ex: test/000037/000037-0001844.flac
+        status = df.at[i, "status"]
+        speaker_id = str(df.at[i, "speaker_id"]).zfill(6)
+        filename = df.at[i, "filename"]
+        path = Path(audio_dir).joinpath(status, speaker_id, filename)
+
         wavscp.write(
-            f"{utt_id} sox - -c1 -esigned -r {df.at[i, 'sample_rate']} -twav - < {Path(audio_dir).joinpath(df.at[i, 'filename'])} |\n"
+            f"{utt_id} sox - -c1 -esigned -r {df.at[i, 'sample_rate']} -twav - < {path} |\n"
         )
         utt2spk.write(f"{utt_id} {df.at[i, 'speaker_id']}\n")
 
         # This line will cause in error in versions of Samrómur where the speaker is unknown
-        spk2gender.write(f"{df.at[i, 'speaker_id']} {df.at[i, 'sex'][0]}\n")
+        spk2gender.write(f"{df.at[i, 'speaker_id']} {df.at[i, 'gender'][0]}\n")
 
 
 def clean_dir(datadir):
@@ -105,7 +113,7 @@ def main():
                 append_to_file(df_part, audio_dir, text, wav, utt2spk, spk2gender)
 
             if data_file == "eval":
-                df_part = df[df["status"].str.contains("eval")]
+                df_part = df[df["status"].str.contains("test")]
                 append_to_file(df_part, audio_dir, text, wav, utt2spk, spk2gender)
 
         clean_dir(datadir)

--- a/s5_base/local/samromur_prep_data.py
+++ b/s5_base/local/samromur_prep_data.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 
-# Author: David Erik Mollberg, Inga Run Helgadottir (Reykjavik University)
+# Author: David Erik Mollberg, Inga Run Helgadottir (Reykjavik University), Staffan Hedström
 # Description:
 # This script will output the files text, wav.scp, utt2spk, spk2utt and spk2gender
 # to data/train, data/eval data/test with test/train/eval splits defined in the metadatafile.
@@ -20,7 +20,7 @@ def parse_arguments():
         """
     )
     parser.add_argument(
-        "audio_dir", type=dir_path, help="The Samromur audio file",
+        "audio_dir", type=dir_path, help="The Samromur audio folder",
     )
     parser.add_argument(
         "meta_file", type=file_path, help="The Samromur metadata file",
@@ -89,7 +89,7 @@ def main():
     outdir = args.output_dir
     Path(outdir).mkdir(parents=True, exist_ok=True)
 
-    df = pd.read_csv(metadata, sep="\t", index_col="id")
+    df = pd.read_csv(metadata, sep="\t", index_col="id", dtype={'is_valid': object})
 
     for data_file in ["train", "dev", "eval"]:
         datadir = Path(outdir).joinpath(data_file)


### PR DESCRIPTION
This updates samromur_prep_data to handle some the official release structure

- column "sex" is now "gender"
- when generating filepaths in wavscp. The new folder structure must be handled
- status "eval" is called "test" in the metadata file

New folder structure for audio where previously all audio files where directly in the audio folder.

{audio_folder}{status}{padded_speaker_id}{filename}

audio
└─── test
       └───000038
            │   000038-0001918.flac
            │   000038-0001919.flac
            │   ...
         ...
└─── dev
       └───000098
            │   000098-0012345.flac
            │   000098-0012346.flac
            │   ...
         ...
└─── train
       └───000101
            │   000101-0030912.flac
            │   000101-0030913.flac
            │   ...
         ...

 